### PR TITLE
Don't enable debug-assertions in rafx by default in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,11 @@ rapier2d = "0.5"
 sdl2-sys = { version = ">=0.33, <=0.34.2"}
 sdl2 = { version = ">=0.33,<0.34.3", features = ["bundled", "static-link", "raw-window-handle"] }
 
+# Cf. MFEK/skulpin.rlib#2 and aclysma/rafx#180.
+[profile.dev.package.rafx]
+debug-assertions = false
+opt-level = 3
+
 [[example]]
 name = "hello_skulpin_sdl2"
 required-features = []


### PR DESCRIPTION
Prevents use of validation layers which may not be present on host
system.

Closes #2.
Closes MFEK/glif#229.

Cf. https://github.com/aclysma/skulpin/pull/106